### PR TITLE
Implement Mos6502 memory management unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set project level compiler options for all build types
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-unused-parameter")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g --coverage")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 

--- a/include/common/CommonTypes.h
+++ b/include/common/CommonTypes.h
@@ -39,4 +39,24 @@ using byte = unsigned char;
 // use the type 'addr' when referring to 16 bit addresses
 using addr = unsigned short;
 
+/// \union Vaddr
+/// \brief Data structure for referring to virtual memory addresses
+union Vaddr {
+  /// The raw 16-bit address
+  addr val;
+  struct {
+    #ifdef __BIG_ENDIAN__
+      /// The high 8 bits of the address
+      byte hh;
+      /// The low 8 bits of the address
+      byte ll;
+    #else // Little Endian
+      /// The low 8 bits of the address
+      byte ll;
+      /// The high 8 bits of the address
+      byte hh;
+    #endif
+  };
+};
+
 #endif // COMMON_TYPES_H //:~

--- a/include/cpu/AbstractCpu.h
+++ b/include/cpu/AbstractCpu.h
@@ -1,4 +1,4 @@
-//===-- include/cpu/cpu.h - Cpu Base Class ----------------------*- C++ -*-===//
+//===-- include/cpu/AbstractCpu.h - Cpu Base Class --------------*- C++ -*-===//
 //
 //                           The OsNES Project
 //
@@ -13,16 +13,17 @@
 //===----------------------------------------------------------------------===//
 #include "common/CommonTypes.h"
 
-#ifndef CPU_BASE_H
-#define CPU_BASE_H
+#ifndef ABSTRACT_CPU_H
+#define ABSTRACT_CPU_H
 
 namespace Cpu {
 
-class CpuBase {
+class AbstractCpu {
   public:
-    virtual ~CpuBase() {};
+    virtual ~AbstractCpu() {};
     virtual void init() = 0;
     virtual void run() = 0;
+    virtual void reset() = 0;
     virtual void trace() = 0;
     virtual void shutdown() = 0;
 };

--- a/include/cpu/Mos6502.h
+++ b/include/cpu/Mos6502.h
@@ -1,4 +1,4 @@
-//===-- include/cpu/mos6502.h - Mos6502 Cpu Class ---------------*- C++ -*-===//
+//===-- include/cpu/Mos6502.h - Mos6502 Cpu Class ---------------*- C++ -*-===//
 //
 //                           The OsNES Project
 //
@@ -18,14 +18,14 @@
 #include <array>
 
 #include "common/CommonTypes.h"
-#include "cpu/CpuBase.h"
+#include "cpu/AbstractCpu.h"
 #include "cpu/Mos6502Instruction.h"
 #include "memory/Ram.h"
 #include "memory/Reference.h"
 
 namespace Cpu {
 
-class Mos6502 : public CpuBase {
+class Mos6502 : public AbstractCpu {
   public:
 
     // Constructors
@@ -42,6 +42,7 @@ class Mos6502 : public CpuBase {
     // CpuBase class methods
     void init() override;
     void run() override;
+    void reset() override;
     void trace() override;
     void shutdown() override;
 

--- a/include/cpu/Mos6502.h
+++ b/include/cpu/Mos6502.h
@@ -30,7 +30,7 @@ class Mos6502 : public CpuBase {
 
     // Constructors
     Mos6502() : stack(reg.sp) {
-      this->reg.pc = 0;
+      this->reg.pc.val = 0;
       this->reg.ac = 0;
       this->reg.x = 0;
       this->reg.y = 0;
@@ -159,18 +159,7 @@ class Mos6502 : public CpuBase {
     int64 cycleCount;
     // Register structure
     struct {
-      union {
-        addr pc; // Program Counter
-        struct {
-#ifdef __BIG_ENDIAN__
-          byte pch;
-          byte pcl;
-#else // Little Endian
-          byte pcl;
-          byte pch;
-#endif // __BIG_ENDIAN__
-        };
-      };
+      Vaddr pc; // Program counter
       byte  ac; // Accumulator
       byte  x;  // X Register
       byte  y;  // Y Register

--- a/include/cpu/Mos6502Mmu.h
+++ b/include/cpu/Mos6502Mmu.h
@@ -1,0 +1,106 @@
+//===-- include/cpu/Mos6502Mmu.h - Memory Management Unit -------*- C++ -*-===//
+//
+//                           The OsNES Project
+//
+// This file is distributed under GPL v2. See LICENSE.md for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the Mos6502 memory management unit
+///
+//===----------------------------------------------------------------------===//
+#ifndef MOS6502_MMU_H
+#define MOS6502_MMU_H
+
+#include "common/CommonTypes.h"
+#include "memory/Ram.h"
+#include "memory/Rom.h"
+#include "memory/Mapper.h"
+#include "memory/Reference.h"
+
+namespace Cpu {
+
+/// \class Mos6502Mmu
+/// \brief This class represents the memory management unit for the Mos6502.
+/// This class is responsible for taking virtual addresses and converting
+/// them into references to real hardware.
+class Mos6502Mmu {
+  public:
+    // Constructors / Destructors
+    Mos6502Mmu(const byte& regX, const byte& regY, const Memory::Mapper<byte>& memMap);
+    ~Mos6502Mmu() {};
+
+    // Addressing mode functions
+    /// Absolute addressing mode, operand is at the address
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> absolute(Vaddr vaddr);
+
+    /// Absolute addressing X-indexed, operand is at the address incremented by X
+    /// with carry.
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> absoluteXIndexed(Vaddr vaddr);
+
+    /// Absolute addressing Y-indexed, operand is at the address incremented by Y
+    /// with carry.
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> absoluteYIndexed(Vaddr vaddr);
+
+    /// Indirect addressing, operand is at the effective address; effective address 
+    /// is the value at the given address
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> indirect(Vaddr vaddr);
+
+    /// X-indexed indirect addressing, operand is effective zeropage address; 
+    /// effective address is byte (BB) incremented by X without carry
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> xIndexedIndirect(Vaddr vaddr);
+
+    /// Indirect addressing Y-indexed, operand is effective address incremented by
+    /// Y with carry; effective address is word at zeropage address
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> indirectYIndexed(Vaddr vaddr);
+
+    /// Zeropage addressing, operand is at address; address hibyte is 0
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> zeropage(Vaddr vaddr);
+
+    /// Zeropage addressing X-indexed, operand is address incremented by X;
+    /// address hibyte = zero ($00xx); no page transition
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> zeropageXIndexed(Vaddr vaddr);
+
+    /// Zeropage addressing Y-indexed, operand is address incremented by Y;
+    /// address hibyte = zero ($00xx); no page transition
+    /// \param vaddr The virtual address to provide a reference for.
+    /// \returns Memory reference for the input address
+    Memory::Reference<byte> zeropageYIndexed(Vaddr vaddr);
+
+  private:
+    /// External register value to use as X-index
+    const byte& indexRegX;
+
+    /// External register value to use as Y-index
+    const byte& indexRegY;
+
+    /// Reference to the memory mapper to use.
+    const Memory::Mapper<byte>& memoryMap;
+
+    // Private implementation functions
+    inline Memory::Reference<byte> absoluteImpl(Vaddr vaddr) const;
+    inline Memory::Reference<byte> zeropageImpl(Vaddr vaddr) const;
+    inline Vaddr indirectImpl(Vaddr vaddr) const;
+
+};
+
+} // namespace Cpu
+
+#endif // MOS6502_MMU_H //:~

--- a/include/memory/AbstractMemory.h
+++ b/include/memory/AbstractMemory.h
@@ -1,0 +1,40 @@
+//===-- include/memory/AbstactMemory.h - Abstact Memory ---------*- C++ -*-===//
+//
+//                           The OsNES Project
+//
+// This file is distributed under GPL v2. See LICENSE.md for details.
+//  
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines the Memory::AbstractMemory abstract class, which serves 
+/// as base class for all memory objects.
+///
+//===----------------------------------------------------------------------===//
+#ifndef ABSTRACT_MEMORY_H
+#define ABSTRACT_MEMORY_H
+
+namespace Memory {
+
+/// \class AbstractMemory
+/// \brief This class represents an abstract piece of memory.
+template<class Wordsize>
+class AbstractMemory {
+  public:
+    virtual ~AbstractMemory() {}
+
+    /// Write data word to the index in memory.
+    /// \param index Index into the memory array
+    /// \param data Word to store at the index
+    virtual void write(std::size_t index, Wordsize data) = 0;
+
+    /// Read data word from the index into memory.
+    /// \param index Index into the memory array
+    /// \returns Word at the given index
+    virtual const Wordsize read(std::size_t index) const = 0;
+
+};
+
+} // namespace Memory
+
+#endif // ABSTRACT_MEMORY_H //

--- a/include/memory/Bank.h
+++ b/include/memory/Bank.h
@@ -14,6 +14,8 @@
 #ifndef MEMORY_BANK_H
 #define MEMORY_BANK_H
 
+#include <vector>
+
 #include "common/CommonTypes.h"
 #include "memory/AbstractMemory.h"
 
@@ -24,6 +26,7 @@ class Bank : public AbstractMemory<Wordsize> {
   public:
     // Constructors and Destructors
     inline Bank(std::size_t size);
+    inline Bank(std::size_t size, Vaddr vaddr);
     virtual ~Bank() {};
 
     /// Read word from \p index
@@ -35,20 +38,30 @@ class Bank : public AbstractMemory<Wordsize> {
     /// \returns the size of the memory
     inline std::size_t getSize() const;
 
-  protected:
-    /// Size of the underlying array 
-    std::size_t size;
+    /// Get the base address of this memory bank
+    /// \returns the base address
+    inline Vaddr getBaseAddress() const;
 
+  protected:
     /// The array of data comprising the memory bank
-    std::unique_ptr<Wordsize[]> dataBank;
+    std::vector<Wordsize> dataBank;
+
+    /// The base virtual address of this memory bank
+    Vaddr baseAddress;
 };
 
 template<class Wordsize>
 Bank<Wordsize>::Bank(std::size_t size) {
-  // Store the memory bank size
-  this->size = size;
   // Initialize the memory bank
-  this->dataBank = std::make_unique<Wordsize[]>(size);
+  this->dataBank.resize(size);
+  this->baseAddress.val = 0;
+}
+
+template<class Wordsize>
+Bank<Wordsize>::Bank(std::size_t size, Vaddr vaddr) {
+  // Initialize the memory bank
+  this->dataBank.resize(size);
+  this->baseAddress.val = vaddr.val;
 }
 
 template<class Wordsize>
@@ -59,7 +72,12 @@ const Wordsize Bank<Wordsize>::read(std::size_t index) const {
 
 template<class Wordsize>
 std::size_t Bank<Wordsize>::getSize() const {
-  return size;
+  return dataBank.size();
+}
+
+template<class Wordsize>
+Vaddr Bank<Wordsize>::getBaseAddress() const {
+  return baseAddress;
 }
 
 } // namespace Memory

--- a/include/memory/Bank.h
+++ b/include/memory/Bank.h
@@ -15,25 +15,21 @@
 #define MEMORY_BANK_H
 
 #include "common/CommonTypes.h"
+#include "memory/AbstractMemory.h"
 
 namespace Memory {
 
 template<class Wordsize> 
-class Bank {
+class Bank : public AbstractMemory<Wordsize> {
   public:
     // Constructors and Destructors
     inline Bank(std::size_t size);
     virtual ~Bank() {};
 
-    /// Write word \p data at \p index
-    /// \param index Index into the dataBank array
-    /// \param data Word to store at \p index
-    virtual void write(std::size_t index, Wordsize data) = 0;
-
     /// Read word from \p index
     /// \param index Index into the dataBank array
     /// \returns word at the given index
-    virtual inline const Wordsize read(std::size_t index) const final;
+    inline const Wordsize read(std::size_t index) const final;
 
     /// Get the size of the memory
     /// \returns the size of the memory

--- a/include/memory/Mapper.h
+++ b/include/memory/Mapper.h
@@ -32,7 +32,7 @@ class Mapper {
     /// This function maps a virtual address to its associated hardware unit.
     /// \param address Address to find the hardware for.
     /// \returns A shared pointer to the hardware resource.
-    virtual std::shared_ptr<Bank<Wordsize>> mapToHardware(Vaddr address) const = 0;
+    virtual std::shared_ptr<Bank<Wordsize>> mapToHardware(Vaddr vaddr) const = 0;
 
 };
 

--- a/include/memory/Mapper.h
+++ b/include/memory/Mapper.h
@@ -1,0 +1,41 @@
+//===-- include/memory/Mapper.h - Abstact Memory Mapper ----------*- C++ -*-===//
+//
+//                           The OsNES Project
+//
+// This file is distributed under GPL v2. See LICENSE.md for details.
+//  
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file declares the abstract Memory::Mapper class.
+///
+//===----------------------------------------------------------------------===//
+#ifndef MEMORY_MAPPER_H
+#define MEMORY_MAPPER_H
+
+#include <memory>
+
+#include "common/CommonTypes.h"
+#include "memory/Bank.h"
+
+namespace Memory {
+
+/// \class Mapper
+/// \brief This class represents an abstract memory mapper, mapping addresses in
+/// the virtual address space to real hardware units. This abstract class serves
+/// as a contract for any class mapping addresses to hardware.
+template<class Wordsize>
+class Mapper {
+  public:
+    virtual ~Mapper() {}
+
+    /// This function maps a virtual address to its associated hardware unit.
+    /// \param address Address to find the hardware for.
+    /// \returns A shared pointer to the hardware resource.
+    virtual std::shared_ptr<Bank<Wordsize>> mapToHardware(Vaddr address) const = 0;
+
+};
+
+} // namespace Memory
+
+#endif // MEMORY_MAPPER_H //

--- a/include/memory/Ram.h
+++ b/include/memory/Ram.h
@@ -27,6 +27,7 @@ class Ram : public Bank<Wordsize> {
   public:
     // Constructors
     Ram(std::size_t size) : Bank<Wordsize>(size) {};
+    Ram(std::size_t size, Vaddr vaddr) : Bank<Wordsize>(size, vaddr) {};
 
     // Destructor
     virtual ~Ram() {};

--- a/include/memory/Rom.h
+++ b/include/memory/Rom.h
@@ -26,7 +26,7 @@ template<class Wordsize>
 class Rom : public Bank<Wordsize> {
   public:
     // Constructors
-    Rom(std::size_t size) : Bank(size) {};
+    Rom(std::size_t size) : Bank<Wordsize>(size) {};
 
     // Destructor
     virtual ~Rom() {};
@@ -35,7 +35,7 @@ class Rom : public Bank<Wordsize> {
     /// We cannot write to a Rom, so throw a ReadOnlyMemoryException when
     /// this method is called.
     inline void write(std::size_t index, Wordsize data) override;
-    virtual void load() delete;
+    virtual void load() = delete;
 };
 
 template <class Wordsize>

--- a/source/cpu/CMakeLists.txt
+++ b/source/cpu/CMakeLists.txt
@@ -1,4 +1,12 @@
+# ===-- source/cpu/CMakeLists.txt - Cpu build configuration ----------------=== #
+#
+#                            The OsNES Project
+# 
+#  This file is distributed under GPL v2. See LICENSE.md for details.
+#
+# ===----------------------------------------------------------------------=== #
 set(SRCS Mos6502.cpp
+         Mos6502Mmu.cpp
          Mos6502Disassembler.cpp)
 
 add_library(cpu ${SRCS})

--- a/source/cpu/Mos6502.cpp
+++ b/source/cpu/Mos6502.cpp
@@ -25,6 +25,9 @@ void Mos6502::init() {
 void Mos6502::run() {
 }
 
+void Mos6502::reset() {
+}
+
 void Mos6502::trace() {
 }
 

--- a/source/cpu/Mos6502.cpp
+++ b/source/cpu/Mos6502.cpp
@@ -57,7 +57,7 @@ int64 Mos6502::getCycleCount() {
 }
 
 addr Mos6502::getRegPC() {
-  return reg.pc;
+  return reg.pc.val;
 }
 
 byte Mos6502::getRegAC() {

--- a/source/cpu/Mos6502Mmu.cpp
+++ b/source/cpu/Mos6502Mmu.cpp
@@ -1,0 +1,107 @@
+//===-- source/cpu/Mos6502Mmu.cpp - Mos6502 Cpu Class Impl ---------*- C++ -*-===//
+//
+//                           The OsNES Project
+//
+// This file is distributed under GPL v2. See LICENSE.md for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of the Cpu memory management unit.
+///
+//===----------------------------------------------------------------------===//
+#include "cpu/CpuException.h"
+#include "cpu/Mos6502Mmu.h"
+
+using namespace Cpu;
+using namespace Memory;
+
+// Constructor
+Mos6502Mmu::Mos6502Mmu(
+    const byte& regX, 
+    const byte& regY, 
+    const Mapper<byte>& memMap) :
+  indexRegX(regX),
+  indexRegY(regY),
+  memoryMap(memMap) {}
+
+//===---------------------------------------------------------------------===//
+// Private inlined implementation functions
+//===---------------------------------------------------------------------===//
+Reference<byte> Mos6502Mmu::absoluteImpl(Vaddr vaddr) const {
+  // Map this virtual address to its corresponding hardware bank.
+  std::shared_ptr<Bank<byte>> dataBank = memoryMap.mapToHardware(vaddr);
+  // Compute the index into this dataBank by subtracting the base address
+  std::size_t index = vaddr.val - dataBank->getBaseAddress().val;
+  return Reference<byte>(dataBank, index);
+}
+
+Vaddr Mos6502Mmu::indirectImpl(Vaddr vaddr) const {
+  // Compute the absolute address to use
+  std::shared_ptr<Bank<byte>> dataBank = memoryMap.mapToHardware(vaddr);
+  std::size_t index = vaddr.val - dataBank->getBaseAddress().val;
+  // Now grab the real address
+  Vaddr effectiveAddress;
+  effectiveAddress.ll = dataBank->read(index);
+  effectiveAddress.hh = dataBank->read(index + 1);
+  return effectiveAddress;
+}
+
+Reference<byte> Mos6502Mmu::zeropageImpl(Vaddr vaddr) const {
+  // find the zeropage memory bank. since we are on the zeropage, we do not
+  // need to compute a new index. vaddr's low byte is sufficient
+  std::shared_ptr<Bank<byte>> dataBank = memoryMap.mapToHardware(vaddr);
+  return Reference<byte>(dataBank, vaddr.ll);
+}
+
+//===---------------------------------------------------------------------===//
+// Mos6502Mmu member functions
+//===---------------------------------------------------------------------===//
+Reference<byte> Mos6502Mmu::absolute(Vaddr vaddr) {
+  return absoluteImpl(vaddr);
+}
+
+Reference<byte> Mos6502Mmu::absoluteXIndexed(Vaddr vaddr) {
+  // Add with carry the index X to the virtual address
+  vaddr.val += indexRegX;
+  return absoluteImpl(vaddr);
+}
+
+Reference<byte> Mos6502Mmu::absoluteYIndexed(Vaddr vaddr) {
+  // Add with carry the index Y to the virtual address
+  vaddr.val += indexRegY;
+  return absoluteImpl(vaddr);
+}
+
+Reference<byte> Mos6502Mmu::indirect(Vaddr vaddr) {
+  return absoluteImpl(indirectImpl(vaddr));
+}
+
+Reference<byte> Mos6502Mmu::xIndexedIndirect(Vaddr vaddr) {
+  // Increment the low byte of our address without carry; ensure high byte is zero.
+  vaddr.ll += indexRegX;
+  vaddr.hh = 0;
+  // do indirect addressing.
+  return absoluteImpl(indirectImpl(vaddr));
+}
+
+Reference<byte> Mos6502Mmu::indirectYIndexed(Vaddr vaddr) {
+  // Compute the effective address, increment by Y and read from that address.
+  Vaddr effectiveAddress = indirectImpl(vaddr);
+  effectiveAddress.val += indexRegY;
+  return absoluteImpl(effectiveAddress);
+}
+
+Reference<byte> Mos6502Mmu::zeropage(Vaddr vaddr) {
+  return zeropageImpl(vaddr);
+}
+
+Reference<byte> Mos6502Mmu::zeropageXIndexed(Vaddr vaddr) {
+  vaddr.ll += indexRegX;
+  return zeropageImpl(vaddr);
+}
+
+Reference<byte> Mos6502Mmu::zeropageYIndexed(Vaddr vaddr) {
+  vaddr.ll += indexRegY;
+  return zeropageImpl(vaddr);
+}

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -6,4 +6,4 @@
 #
 # ===----------------------------------------------------------------------=== #
 set(SRCS TestException.cpp)
-add_test_suite(CommonTests ${SRCS})
+add_test_suite(CommonTests "${SRCS}")

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -5,6 +5,7 @@
 #  This file is distributed under GPL v2. See LICENSE.md for details.
 #
 # ===----------------------------------------------------------------------=== #
-set(SRCS TestMos6502.cpp)
+set(SRCS TestMos6502.cpp
+         TestMos6502Mmu.cpp)
 include_directories(${CMAKE_SOURCE_DIR}/source/cpu)
-add_test_suite(CpuTests ${SRCS})
+add_test_suite(CpuTests "${SRCS}")

--- a/tests/cpu/TestMos6502Mmu.cpp
+++ b/tests/cpu/TestMos6502Mmu.cpp
@@ -1,0 +1,359 @@
+//===-- tests/cpu/TestMos6502Mmu.cpp - Mos6502 MMU Test ---------*- C++ -*-===//
+//
+//                           The OsNES Project
+//
+// This file is distributed under GPL v2. See LICENSE.md for details. The Catch
+// framework IS NOT distributed under LICENSE.md.
+// The Catch framework is included in this project under the Boost License
+// simply as a matter of convenience.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Test cases for the Mos6502 MMU class
+///
+//===----------------------------------------------------------------------===//
+#include <array>
+#include <memory>
+
+#include "tests/catch.hpp"
+#include "common/CommonTypes.h"
+#include "memory/Mapper.h"
+#include "memory/Bank.h"
+#include "memory/Ram.h"
+#include "cpu/Mos6502Mmu.h"
+
+using namespace Memory;
+using namespace Cpu;
+
+#define NUM_BANKS 0x10
+#define BANK_SIZE 0x1000
+
+/// \class MockMapper
+/// \brief A fake memory mapper for testing.
+class MockMapper : public Mapper<byte> {
+  public:
+    MockMapper();
+    ~MockMapper() {}
+    std::shared_ptr<Bank<byte>> mapToHardware(Vaddr vaddr) const override;
+  private:
+    /// An array of ptrs to Ram banks that can be mapped to
+    std::array<std::shared_ptr<Ram<byte>>, NUM_BANKS> dataBanks;
+};
+
+MockMapper::MockMapper() {
+  Vaddr vaddr;
+  // bootstrap the mock mapper.
+  for(std::size_t i = 0; i < NUM_BANKS; i++) {
+    vaddr.val = i * BANK_SIZE;
+    dataBanks[i] = std::make_shared<Ram<byte>>(BANK_SIZE, vaddr);
+  }
+}
+
+std::shared_ptr<Bank<byte>> MockMapper::mapToHardware(Vaddr vaddr) const {
+  // mask out the high 4 bits and use as an index into the array
+  std::size_t index = (vaddr.val >> 12) & 0xF;
+  return dataBanks[index];
+}
+
+TEST_CASE("Mos6502 Memory Management Unit functionality tests", "[Mos6502],[Mmu]") {
+  // instantiate the base objects needed to use the MMU
+  byte regX = 0;
+  byte regY = 0;
+  auto memMap = MockMapper();
+
+  // build the MMU
+  auto mmu = Mos6502Mmu(regX, regY, memMap);
+
+  SECTION("Absolute addressing has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 5;
+    Vaddr vaddr = {0x1023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, data);
+
+    byte test;
+    auto memRef = mmu.absolute(vaddr);
+    test = memRef.read();
+    CHECK(test == data);
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 7;
+    vaddr.val = 0x1001;
+    memRef = mmu.absolute(vaddr);
+    memRef.write(data);
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val);
+    CHECK(test == data);
+
+  }
+
+  SECTION("Absolute addressing X-indexed has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 5;
+    Vaddr vaddr = {0x1023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + i, data + i);
+    }
+
+    byte test;
+    for(byte i = 0; i < 10; i++) {
+      regX = i;
+      auto memRef = mmu.absoluteXIndexed(vaddr);
+      test = memRef.read();
+      CHECK(test == (data + i));
+    }
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 7;
+    vaddr.val = 0x1001;
+    for(byte i = 0; i < 10; i++) {
+      regX = i;
+      auto memRef = mmu.absoluteXIndexed(vaddr);
+      memRef.write(data + i);
+    }
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val + i);
+      CHECK(test == (data + i));
+    }
+
+  }
+
+  SECTION("Absolute addressing Y-indexed has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 5;
+    Vaddr vaddr = {0x1023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + i, data + i);
+    }
+
+    byte test;
+    for(byte i = 0; i < 10; i++) {
+      regY = i;
+      auto memRef = mmu.absoluteYIndexed(vaddr);
+      test = memRef.read();
+      CHECK(test == (data + i));
+    }
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 7;
+    vaddr.val = 0x1001;
+    for(byte i = 0; i < 10; i++) {
+      regY = i;
+      auto memRef = mmu.absoluteYIndexed(vaddr);
+      memRef.write(data + i);
+    }
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val + i);
+      CHECK(test == (data + i));
+    }
+
+  }
+
+  SECTION("Indirect addressing has the correct behaviour") {
+    // write an address to the memory that points to some other bank containing
+    // data.
+    byte data = 5;
+    Vaddr vaddr = {0x1023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x20);
+    vaddr.val = 0x2023;
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, data);
+
+    byte test;
+    vaddr.val = 0x1023;
+    auto memRef = mmu.indirect(vaddr);
+    test = memRef.read();
+    CHECK(test == data);
+
+    data = 16;
+    vaddr = {0x3001};
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x40);
+    vaddr.val = 0x3001;
+    memRef = mmu.indirect(vaddr);
+    memRef.write(data);
+
+    vaddr.val = 0x4023;
+    ramPtr = memMap.mapToHardware(vaddr);
+    test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val);
+    CHECK(test == data);
+
+  }
+  
+  SECTION("X-indexed indirect addressing has the correct behaviour") {
+    // write an address to the memory that points to some other bank containing
+    // data.
+    byte data = 3;
+    Vaddr vaddr = {0x0025};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x20);
+    vaddr.val = 0x2023;
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, data);
+
+    byte test;
+    regX = 2;
+    vaddr.val = 0x0023;
+    auto memRef = mmu.xIndexedIndirect(vaddr);
+    test = memRef.read();
+    CHECK(test == data);
+
+    data = 117;
+    vaddr = {0x0005};
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x40);
+    regX = 4;
+    vaddr.val = 0x0001;
+    memRef = mmu.xIndexedIndirect(vaddr);
+    memRef.write(data);
+
+    vaddr.val = 0x4023;
+    ramPtr = memMap.mapToHardware(vaddr);
+    test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val);
+    CHECK(test == data);
+
+  }
+
+  SECTION("Indirect Y-indexed addressing has the correct behaviour") {
+    // write an address to the memory that points to some other bank containing
+    // data.
+    byte data = 5;
+    Vaddr vaddr = {0x1023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x20);
+    vaddr.val = 0x2025;
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, data);
+
+    byte test;
+    regY = 2;
+    vaddr.val = 0x1023;
+    auto memRef = mmu.indirectYIndexed(vaddr);
+    test = memRef.read();
+    CHECK(test == data);
+
+    data = 16;
+    vaddr = {0x3001};
+    ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, 0x23);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + 1, 0x40);
+    regY = 4;
+    vaddr.val = 0x3001;
+    memRef = mmu.indirectYIndexed(vaddr);
+    memRef.write(data);
+
+    vaddr.val = 0x4027;
+    ramPtr = memMap.mapToHardware(vaddr);
+    test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val);
+    CHECK(test == data);
+
+  }
+
+  SECTION("Zeropage addressing has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 25;
+    Vaddr vaddr = {0x0023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val, data);
+
+    byte test;
+    auto memRef = mmu.zeropage(vaddr);
+    test = memRef.read();
+    CHECK(test == data);
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 7;
+    vaddr.hh = 0x0;
+    vaddr.ll = 0x01;
+    memRef = mmu.zeropage(vaddr);
+    memRef.write(data);
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val);
+    CHECK(test == data);
+
+  }
+
+  SECTION("Zeropage addressing X-indexed has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 10;
+    Vaddr vaddr = {0x0023};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + i, data + i);
+    }
+
+    byte test;
+    for(byte i = 0; i < 10; i++) {
+      regX = i;
+      auto memRef = mmu.zeropageXIndexed(vaddr);
+      test = memRef.read();
+      CHECK(test == (data + i));
+    }
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 30;
+    vaddr.val = 0x0001;
+    for(byte i = 0; i < 10; i++) {
+      regX = i;
+      auto memRef = mmu.zeropageXIndexed(vaddr);
+      memRef.write(data + i);
+    }
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val + i);
+      CHECK(test == (data + i));
+    }
+
+  }
+
+  SECTION("Zeropage addressing Y-indexed has the correct behaviour") {
+    // Write some memory to the ram, and try reading it from the MMU
+    byte data = 100;
+    Vaddr vaddr = {0x0050};
+    auto ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      ramPtr->write(vaddr.val - ramPtr->getBaseAddress().val + i, data + i);
+    }
+
+    byte test;
+    for(byte i = 0; i < 10; i++) {
+      regY = i;
+      auto memRef = mmu.zeropageYIndexed(vaddr);
+      test = memRef.read();
+      CHECK(test == (data + i));
+    }
+
+    // Now write some data to the Ram using a reference from the MMU
+    data = 7;
+    vaddr.val = 0x0001;
+    for(byte i = 0; i < 10; i++) {
+      regY = i;
+      auto memRef = mmu.zeropageYIndexed(vaddr);
+      memRef.write(data + i);
+    }
+
+    ramPtr = memMap.mapToHardware(vaddr);
+    for(byte i = 0; i < 10; i++) {
+      test = ramPtr->read(vaddr.val - ramPtr->getBaseAddress().val + i);
+      CHECK(test == (data + i));
+    }
+
+  }
+
+}

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -6,5 +6,5 @@
 #
 # ===----------------------------------------------------------------------=== #
 set(SRCS TestReference.cpp
-  TestRam.cpp)
-add_test_suite(MemoryTests ${SRCS})
+         TestRam.cpp)
+add_test_suite(MemoryTests "${SRCS}")


### PR DESCRIPTION
### Task
Resolves #3 

### Code Change
- add a Mos6502 MMU class that will handle all non-trivial addressing modes
- add a Memory mapper base class to be used by the MMU.
- add tests for the MMU.

### Side Effects
None

### Dependencies
None

### Reviewers
- [ ] @KristonCosta 
